### PR TITLE
GPII-2630: Adjusted to accommodate the implemetation of the new GPII data model

### DIFF
--- a/components.conf
+++ b/components.conf
@@ -1,4 +1,3 @@
 # Whitespace-separated list of components of the form 'service|image|tag'.
 flowmanager|gpii/universal|latest
-preferences-dataloader|gpii/preferences-dataloader|latest
-preferences|gpii/universal|latest
+gpii-dataloader|gpii/gpii-dataloader|latest

--- a/components.conf
+++ b/components.conf
@@ -1,3 +1,4 @@
 # Whitespace-separated list of components of the form 'service|image|tag'.
 flowmanager|gpii/universal|latest
+preferences|gpii/universal|latest
 gpii-dataloader|gpii/gpii-dataloader|latest

--- a/update-version
+++ b/update-version
@@ -12,7 +12,7 @@ for component in $COMPONENTS ; do
     echo "Looking up '$image:$tag' for service '$service'..."
     api_token=$(\
         curl -L -s \
-        --retry 3 --retry-delay 1 --retry-connrefused \
+        --retry 3 --retry-delay 1 \
         "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$image:pull" \
         | jq -r .token \
     )
@@ -20,7 +20,7 @@ for component in $COMPONENTS ; do
     # https://stackoverflow.com/questions/39375421/can-i-get-an-image-digest-without-downloading-the-image.
     api_out=$(\
         curl -L -s \
-        --retry 3 --retry-delay 1 --retry-connrefused \
+        --retry 3 --retry-delay 1 \
         --head \
         -H "Authorization: Bearer $api_token" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \

--- a/update-version
+++ b/update-version
@@ -12,7 +12,7 @@ for component in $COMPONENTS ; do
     echo "Looking up '$image:$tag' for service '$service'..."
     api_token=$(\
         curl -L -s \
-        --retry 3 --retry-delay 1 \
+        --retry 3 --retry-delay 1 --retry-connrefused \
         "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$image:pull" \
         | jq -r .token \
     )
@@ -20,7 +20,7 @@ for component in $COMPONENTS ; do
     # https://stackoverflow.com/questions/39375421/can-i-get-an-image-digest-without-downloading-the-image.
     api_out=$(\
         curl -L -s \
-        --retry 3 --retry-delay 1 \
+        --retry 3 --retry-delay 1 --retry-connrefused \
         --head \
         -H "Authorization: Bearer $api_token" \
         -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \


### PR DESCRIPTION
The changes include:
1. The `preferences` container is no longer needed;
2. Renamed "preferences-dataloader" to "gpii-dataloader". 

Note that the option "--retry-connrefused" in `update-version` has been removed because it causes failure when running this script in mac OSX. Ops team, please double check if this removal affects elsewhere.

This pull request should be merged once https://github.com/GPII/universal/pull/591 is merged into the universal master branch.