### PR TITLE
Stop fetching tags also for gitlab remote

### DIFF
--- a/update-version-wrapper
+++ b/update-version-wrapper
@@ -18,7 +18,7 @@ rm -rf gpii-infra
 # updated in a bit.
 git clone --no-tags --depth 10 git@github.com:gpii-ops/gpii-infra
 cd gpii-infra
-git remote add gitlab git@gitlab.com:gpii-ops/gpii-infra
+git remote add --no-tags gitlab git@gitlab.com:gpii-ops/gpii-infra
 
 # Failures in the main loop are ok, so continue if anything fails and try again
 # on the next go around.


### PR DESCRIPTION
This stops fetching tags for the additional remote as well, tested locally.

```
$ ./update-version-wrapper
git config --global user.email gpii-bot@gpii.net
git config --global user.name GPII Bot
Cloning into 'gpii-infra'...
remote: Counting objects: 449, done.
remote: Compressing objects: 100% (325/325), done.
remote: Total 449 (delta 134), reused 273 (delta 78), pack-reused 0
Receiving objects: 100% (449/449), 156.54 KiB | 566.00 KiB/s, done.
Resolving deltas: 100% (134/134), done.
Starting version check at Thu 30 Aug 2018 13:47:19 CEST
Fetching origin
Fetching gitlab
From github.com:gpii-ops/gpii-infra
 * [new branch]      master     -> gitlab/master
HEAD is now at fd20c56 [auto] Update common/versions.yml
Looking up 'gpii/universal:latest' for service 'gpii-flowmanager'...
...found digest 'sha256:96bd98105e465c4e1881f0faf93449d5f1a1ae1d44d123bac617d247ce9fb0b9'.
Looking up 'gpii/universal:latest' for service 'gpii-preferences'...
...found digest 'sha256:96bd98105e465c4e1881f0faf93449d5f1a1ae1d44d123bac617d247ce9fb0b9'.
Looking up 'gpii/gpii-dataloader:latest' for service 'gpii-dataloader'...
```