### PR TITLE
GPII-3356 - Change the destination path to common/versions.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@ This repo contains a Docker image for tracking versions of GPII components to be
 For more about the general CI/CD picture, see [Continuous Integration / Continuous Delivery in gpii-infra](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md).
 
 This module contains:
-* `update-version`, which calculates the latest sha256 for each component and writes `common/versions.yml` in the [gpii-infra repo](https://github.com/gpii-ops/gpii-infra/).
+* `update-version`, which calculates the latest sha256 for each component and writes `shared/versions.yml` in the [gpii-infra repo](https://github.com/gpii-ops/gpii-infra/).
 * `components.conf`, a list of GPII components and the Docker images and tags that run them. This file is consumed by `update-version`.
-* `update-version-wrapper`, a script that runs `update-version` in a loop, committing and pushing `common/versions.yml` if it changes.
+* `update-version-wrapper`, a script that runs `update-version` in a loop, committing and pushing `shared/versions.yml` if it changes.
    * This requires commit and push privileges on `gpii-infra`. These privileges are provided via an [ssh key](https://github.com/gpii-ops/gpii-infra/#configure-ssh) and some configuration of [Github](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-github) and [Gitlab](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-gitlab).
 * `Dockerfile`, to build a Docker image that runs `update-version-wrapper`.
    * A container based on this Docker image is deployed to `i46` and managed by an [Ansible role](https://github.com/idi-ops/ansible-gpii-version-updater) and a [wrapper playbook](https://github.com/inclusive-design/ops/blob/master/ansible/config_host_gpii_version_updater.yml).
 
-## Generating `common/versions.yml` manually
+## Generating `shared/versions.yml` manually
 
 `update-version` can be useful for local GPII development. See [gpii-infra: I want to test my local changes to GPII components in my cluster](https://github.com/gpii-ops/gpii-infra#i-want-to-test-my-local-changes-to-gpii-components-in-my-cluster).

--- a/update-version-wrapper
+++ b/update-version-wrapper
@@ -4,7 +4,7 @@
 set -e
 
 orig_dir="$(pwd)"
-versions_file='common/versions.yml'
+versions_file='shared/versions.yml'
 
 export GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa.gpii-ci'
 git config --global user.email "gpii-bot@gpii.net"


### PR DESCRIPTION
This changes is needed if all the shared resources used by the project types are relocated in the `shared` directory instead of the `common` directory: https://github.com/gpii-ops/gpii-infra/pull/131

This PR should be merged right after the https://github.com/gpii-ops/gpii-infra/pull/131 is merged in order to avoid the creation of new files in the destination repository.