### PR TITLE
GPII-3391, GPII-3138: New dataloader in universal

### DIFF
--- a/components.conf
+++ b/components.conf
@@ -1,4 +1,4 @@
 # Whitespace-separated list of components of the form 'service|image|tag'.
 gpii-flowmanager|gpii/universal|latest
 gpii-preferences|gpii/universal|latest
-gpii-dataloader|gpii/gpii-dataloader|latest
+gpii-dataloader|gpii/universal|latest


### PR DESCRIPTION
Move to a new version of data loader that is now part of universal.

This needs to wait for https://github.com/GPII/universal/pull/692 and go together with https://github.com/gpii-ops/gpii-infra/pull/163. See https://github.com/gpii-ops/gpii-infra/pull/163 for more details.