### PR TITLE
GPII-3563 - Remove push to Gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module contains:
 * `update-version`, which calculates the latest sha256 for each component and writes `shared/versions.yml` in the [gpii-infra repo](https://github.com/gpii-ops/gpii-infra/).
 * `components.conf`, a list of GPII components and the Docker images and tags that run them. This file is consumed by `update-version`.
 * `update-version-wrapper`, a script that runs `update-version` in a loop, committing and pushing `shared/versions.yml` if it changes.
-   * This requires commit and push privileges on `gpii-infra`. These privileges are provided via an [ssh key](https://github.com/gpii-ops/gpii-infra/#configure-ssh) and some configuration of [Github](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-github) and [Gitlab](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-gitlab).
+   * This requires commit and push privileges on `gpii-infra`. These privileges are provided via an [ssh key](https://github.com/gpii-ops/gpii-infra/#configure-ssh) and some configuration of [Github](https://github.com/gpii-ops/gpii-infra/blob/master/CI-CD.md#configure-github).
 * `Dockerfile`, to build a Docker image that runs `update-version-wrapper`.
    * A container based on this Docker image is deployed to `i46` and managed by an [Ansible role](https://github.com/idi-ops/ansible-gpii-version-updater) and a [wrapper playbook](https://github.com/inclusive-design/ops/blob/master/ansible/config_host_gpii_version_updater.yml).
 

--- a/update-version-wrapper
+++ b/update-version-wrapper
@@ -18,7 +18,6 @@ rm -rf gpii-infra
 # updated in a bit.
 git clone --no-tags --depth 10 git@github.com:gpii-ops/gpii-infra
 cd gpii-infra
-git remote add --no-tags gitlab git@gitlab.com:gpii-ops/gpii-infra
 
 # Failures in the main loop are ok, so continue if anything fails and try again
 # on the next go around.
@@ -33,7 +32,6 @@ while true ; do
         git add "${versions_file}"
         git commit -m"[auto] Update ${versions_file}"
         git push origin HEAD
-        git push gitlab HEAD
     fi
 
     sleep_secs=300


### PR DESCRIPTION
Related to recent issue when version-updater was unable to push to GitHub, but would succeed in pushing to GitLab, and this causing loop where GH would fight with GL and pile up tons of CI builds, we've decided to disable version-updater pushes to GitLab to prevent this split-brain behavior possibility.