### PR TITLE
GPII-3861: dev workflow (push_to_gcr, desired_components)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,29 @@ This module contains:
 ## Generating `shared/versions.yml` manually
 
 `sync_images` can be useful for local GPII development. See [gpii-infra: I want to test my local changes to GPII components in my cluster](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/README.md#i-want-to-test-my-local-changes-to-gpii-components-in-my-cluster).
+
+## Adding or modifying a component
+
+`sync_images` reads a specified `versions.yml` file.
+
+Each top-level key is a `component`. The component's name is arbitrary, but should correlate with a gpii-infra module since gpii-infra will populate environment variables like `TF_VAR_<component_name>_(repository|tag|sha)` based on data under the component key in `versions.yml`.
+
+`sync_images` pulls the image specified by the component's `upstream_image` key, optionally processes the image further (e.g. push it to GCR), then populates the component's `generated` key with caluclated values.
+
+### To add a new component
+
+1. Add a new top-level key, `my_component`.
+   * Use `snake_case`, not `kebab-case`.
+1. Add a key underneath `my_component` called `repository`. Its value is the upstream location of the image, e.g. `mrtyler/universal` or `couchdb`.
+1. Add a key underneath `my_component` called `tag`. Its value is the tag on the upstream repository, e.g. `latest` or `2.3`.
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, my_component]"`
+   * `desired_components` (the last argument) accepts multiple, pipe-separated values: `flowmanager|preferences|dataloader`
+1. Review the changes made to `versions.yml` and commit.
+
+### To modify a component
+
+1. Find the component, e.g. `your_component`.
+1. Modify `repository` and `tag`.
+1. Ignore everything under `generated`; it will be re-generated.
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, your_component]"`
+1. Review the changes made to `versions.yml` and commit.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This module contains:
    * To clean up: `rake uninstall`
 
 ## Running on host
-* `rake sync` to run `sync_images.rb` (see below)
+* `rake sync` to run `sync_images.rb`
    * You can override some defaults: `rake sync"[./my_versions.yml, gcr.io/gpii2test-common-stg]"`
 * `rake clean_cache` to destroy the Docker `/var/lib/docker` cache volume. The volume and cache will be re-created on the next run.
 * `rake test` to run unit tests
@@ -36,7 +36,9 @@ This workflow is a little cumbersome and is probably best for debugging version-
       * Add to the command line: `-v $(pwd)/fake-gpii-ci-ssh:/root/.ssh:ro,Z`
    * If you want to upload images (i.e. `push_to_gcr` is set to `true` -- this is the default for `sync_images_wrapper`), you must provide credentials with write access to the production GCR instance (or to the GCR instance you specified).
       * Add to the command line: `-v $(pwd)/creds.json:/home/app/creds.json:ro,Z`
-   * Omit `version-updater-docker-cache` if you want to re-pull the Docker images whenever you restart the container. Otherwise, provide the `-v version-updater-docker-cache` argument and clean it up afterwards with `rake clean_cache`.
+   * Omit `version-updater-docker-cache` if you want to re-pull the Docker images whenever you restart the container. Otherwise, clean up afterwards with `rake clean_cache`.
+1. Inside the container, start dockerd in the background: `dockerd &`
+1. `rake sync"[/path/to/versions.yml]"`, etc.
 
 ## Generating `shared/versions.yml` manually
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :test do
 end
 
 desc "Sync images"
-task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
+task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
     main(

--- a/Rakefile
+++ b/Rakefile
@@ -22,15 +22,15 @@ task :test do
   sh "bundle exec rspec"
 end
 
-desc "Sync images -- positional args are config_file, registry_url, push_to_gcr, desired_components"
-task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
+desc "Sync images -- positional args are config_file, desired_components, push_to_gcr, registry_url"
+task :sync, [:config_file, :desired_components, :push_to_gcr, :registry_url] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
     main(
       config_file=\"#{args[:config_file]}\",
-      registry_url=\"#{args[:registry_url]}\",
-      push_to_gcr=\"#{args[:push_to_gcr]}\",
       desired_components=\"#{args[:desired_components]}\",
+      push_to_gcr=\"#{args[:push_to_gcr]}\",
+      registry_url=\"#{args[:registry_url]}\",
     ); \
   '"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,28 @@
+BUNDLE_PATH = "vendor/bundle"
+
 task :default => [:test]
+
+desc "Install dependencies"
+task :install do
+  sh "bundle install --path #{BUNDLE_PATH}"
+end
+
+desc "Uninstall dependencies"
+task :uninstall do
+  sh "rm -rf #{BUNDLE_PATH}"
+end
+
+desc "Destroy volume containing docker image cache"
+task :clean_cache do
+  sh "docker volume rm -f version-updater-docker-cache"
+end
 
 desc "Run tests"
 task :test do
   sh "bundle exec rspec"
 end
 
-desc "Sync images"
+desc "Sync images -- positional args are config_file, registry_url, push_to_gcr, desired_components"
 task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
@@ -16,11 +33,6 @@ task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do 
       desired_components=\"#{args[:desired_components]}\",
     ); \
   '"
-end
-
-desc "Destroy volume containing docker image cache"
-task :clean do
-  sh "docker volume rm -f version-updater-docker-cache"
 end
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,14 @@ task :test do
 end
 
 desc "Sync images"
-task :sync, [:config_file, :registry_url] do |taskname, args|
+task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
-    main(config_file=\"#{args[:config_file]}\", registry_url=\"#{args[:registry_url]}\") \
+    main(
+      config_file=\"#{args[:config_file]}\",
+      registry_url=\"#{args[:registry_url]}\",
+      push_to_gcr=\"#{args[:push_to_gcr]}\",
+    ); \
   '"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
       config_file=\"#{args[:config_file]}\",
       registry_url=\"#{args[:registry_url]}\",
       push_to_gcr=\"#{args[:push_to_gcr]}\",
+      desired_components=\"#{args[:desired_components]}\",
     ); \
   '"
 end

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -24,13 +24,14 @@ describe SyncImages do
       },
     }
     fake_registry_url = "gcr.fake/fake-project"
+    fake_push_to_gcr = true
 
     allow(SyncImages).to receive(:process_image)
 
-    SyncImages.process_config(fake_config, fake_registry_url)
+    SyncImages.process_config(fake_config, fake_registry_url, fake_push_to_gcr)
 
-    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url)
-    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url)
+    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
   end
 
   it "process_config generates new config" do
@@ -45,6 +46,7 @@ describe SyncImages do
       },
     }
     fake_registry_url = "gcr.fake/fake-project"
+    fake_push_to_gcr = true
     fake_new_image_name = "fake-registry/gpii/universal"
     fake_sha_1 = "sha256:c0ffee"
     fake_sha_2 = "sha256:50da"
@@ -74,7 +76,7 @@ describe SyncImages do
     )
     allow(SyncImages).to receive(:write_new_config)
 
-    actual = SyncImages.process_config(fake_config, fake_registry_url)
+    actual = SyncImages.process_config(fake_config, fake_registry_url, fake_push_to_gcr)
     expect(actual).to eq(expected_config)
   end
 

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -49,7 +49,7 @@ describe SyncImages do
     }
     fake_registry_url = "gcr.fake/fake-project"
     fake_push_to_gcr = true
-    fake_desired_components = "flowmanager,something_else"
+    fake_desired_components = "flowmanager|something_else"
 
     allow(SyncImages).to receive(:process_image)
 

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -158,7 +158,7 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
     desired_components = SyncImages::DESIRED_COMPONENTS
   end
   config = SyncImages.load_config(config_file)
-  SyncImages.login()
+  SyncImages.login() if push_to_gcr
   SyncImages.process_config(config, registry_url, push_to_gcr, desired_components)
   SyncImages.write_new_config(config_file, config)
 end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -37,12 +37,18 @@ class SyncImages
     return config
   end
 
-  def self.process_image(component, image_name, registry_url)
+  def self.process_image(component, image_name, registry_url, push_to_gcr)
     image = self.pull_image(image_name)
-    new_image_name = self.retag_image(image, registry_url, image_name)
-    new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
-    sha = self.get_sha_from_image(image, new_image_name_without_tag)
-    self.push_image(image, new_image_name)
+    if push_to_gcr
+      new_image_name = self.retag_image(image, registry_url, image_name)
+      new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
+      sha = self.get_sha_from_image(image, new_image_name_without_tag)
+      self.push_image(image, new_image_name)
+    else
+      new_image_name = image_name
+      new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
+      sha = self.get_sha_from_image(image, new_image_name_without_tag)
+    end
 
     return [new_image_name_without_tag, sha, tag]
   end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -29,7 +29,7 @@ class SyncImages
   def self.process_config(config, registry_url, push_to_gcr, desired_components)
     desired_components_table = {}  # Empty hash means "all components"
     unless desired_components.nil?
-      desired_components.split(",").each do |dc|
+      desired_components.split("|").each do |dc|
         desired_components_table[dc] = true
       end
     end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,6 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
+  PUSH_TO_GCR = true
   REGISTRY_URL = "gcr.io/gpii-common-prd"
 
   def self.load_config(config_file)
@@ -24,10 +25,10 @@ class SyncImages
     )
   end
 
-  def self.process_config(config, registry_url)
+  def self.process_config(config, registry_url, push_to_gcr)
     config.keys.sort.each do |component|
       image_name = config[component]["upstream_image"]
-      (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url)
+      (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url, push_to_gcr)
       config[component]["generated"] = {
         "image" => new_image_name,
         "sha" => sha,
@@ -123,16 +124,19 @@ class SyncImages
 end
 
 
-def main(config_file, registry_url)
+def main(config_file, registry_url, push_to_gcr)
   if config_file.nil? or config_file.empty?
     config_file = SyncImages::CONFIG_FILE
   end
   if registry_url.nil? or registry_url.empty?
     registry_url = SyncImages::REGISTRY_URL
   end
+  if push_to_gcr.nil? or push_to_gcr.empty?
+    push_to_gcr = SyncImages::PUSH_TO_GCR
+  end
   config = SyncImages.load_config(config_file)
   SyncImages.login()
-  SyncImages.process_config(config, registry_url)
+  SyncImages.process_config(config, registry_url, push_to_gcr)
   SyncImages.write_new_config(config_file, config)
 end
 

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -53,6 +53,7 @@ class SyncImages
   end
 
   def self.process_image(component, image_name, registry_url, push_to_gcr)
+    puts "Processing image for #{component}..."
     image = self.pull_image(image_name)
     if push_to_gcr
       new_image_name = self.retag_image(image, registry_url, image_name)
@@ -64,6 +65,8 @@ class SyncImages
       new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
       sha = self.get_sha_from_image(image, new_image_name_without_tag)
     end
+    puts "Done with #{component}."
+    puts
 
     return [new_image_name_without_tag, sha, tag]
   end
@@ -148,6 +151,9 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
   if push_to_gcr.nil? or push_to_gcr.empty?
     push_to_gcr = SyncImages::PUSH_TO_GCR
   end
+  # Due to how we pass arguments through rake, 'false' ends up as a string.
+  # Correct it into a boolean.
+  push_to_gcr = false if push_to_gcr == "false"
   if desired_components.nil? or desired_components.empty?
     desired_components = SyncImages::DESIRED_COMPONENTS
   end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,8 +8,10 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = nil  # "nil" means all components
-  PUSH_TO_GCR = true
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "preferences"]
+  DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
+  DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
+  PUSH_TO_GCR = false
   REGISTRY_URL = "gcr.io/gpii-common-prd"
 
   def self.load_config(config_file)
@@ -26,22 +28,22 @@ class SyncImages
     )
   end
 
-  def self.process_config(config, registry_url, push_to_gcr, desired_components)
-    desired_components_table = {}  # Empty hash means "all components"
-    unless desired_components.nil?
-      desired_components.split("|").each do |dc|
-        desired_components_table[dc] = true
-      end
+  def self.process_config(config, desired_components, push_to_gcr, registry_url)
+    if desired_components == SyncImages::DESIRED_COMPONENTS_ALL_TOKEN
+      components = config.keys.sort.each
+    elsif desired_components == SyncImages::DESIRED_COMPONENTS_DEFAULT_TOKEN
+      components = SyncImages::DESIRED_COMPONENTS
+    else
+      components = desired_components.split("|")
     end
 
-    config.keys.sort.each do |component|
-      # Ruby style suggests "unless X or Y", but I find that more confusing than
-      # "if not X and not Y".
-      #
-      # Anyway, skip this component if desired_components were specified AND
-      # this component is not in the set of desired_components.
-      next if (not desired_components_table.empty? and not desired_components_table.has_key?(component))
-      image_name = config[component]["upstream_image"]
+    components.each do |component|
+      begin
+        image_name = config[component]["upstream_image"]
+      rescue
+        puts "Could not find desired component #{component} (or its 'upstream_image' attribute)! Skipping!"
+        next
+      end
       (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url, push_to_gcr)
       config[component]["generated"] = {
         "image" => new_image_name,
@@ -141,12 +143,12 @@ class SyncImages
 end
 
 
-def main(config_file, registry_url, push_to_gcr, desired_components)
+def main(config_file, desired_components, push_to_gcr, registry_url)
   if config_file.nil? or config_file.empty?
     config_file = SyncImages::CONFIG_FILE
   end
-  if registry_url.nil? or registry_url.empty?
-    registry_url = SyncImages::REGISTRY_URL
+  if desired_components.nil? or desired_components.empty?
+    desired_components = SyncImages::DESIRED_COMPONENTS_DEFAULT_TOKEN
   end
   if push_to_gcr.nil? or push_to_gcr.empty?
     push_to_gcr = SyncImages::PUSH_TO_GCR
@@ -154,12 +156,13 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
   # Due to how we pass arguments through rake, 'false' ends up as a string.
   # Correct it into a boolean.
   push_to_gcr = false if push_to_gcr == "false"
-  if desired_components.nil? or desired_components.empty?
-    desired_components = SyncImages::DESIRED_COMPONENTS
+  if registry_url.nil? or registry_url.empty?
+    registry_url = SyncImages::REGISTRY_URL
   end
+
   config = SyncImages.load_config(config_file)
   SyncImages.login() if push_to_gcr
-  SyncImages.process_config(config, registry_url, push_to_gcr, desired_components)
+  SyncImages.process_config(config, desired_components, push_to_gcr, registry_url)
   SyncImages.write_new_config(config_file, config)
 end
 

--- a/sync_images_wrapper
+++ b/sync_images_wrapper
@@ -28,7 +28,7 @@ while true ; do
     git fetch --all --depth=10 -p
     git reset --hard origin/master
 
-    (cd "${orig_dir}" && rake sync"[${gpii_infra_dir}/${versions_file}]")
+    (cd "${orig_dir}" && rake sync"[${gpii_infra_dir}/${versions_file}, ALL, true, gcr.io/gcp-common-prd]")
     if [ -n "$(git status --porcelain -- ${versions_file})" ]; then
         git add "${versions_file}"
         git commit -m"[auto] Update ${versions_file}"


### PR DESCRIPTION
[Rendered README](https://github.com/mrtyler/gpii-version-updater/tree/gpii-3861-for-devs)

The main idea was to make it possible for developers (who can't `docker push` to the production GCR instance and are rarely interested in changing anything other than GPII components) to use `sync_images` to write a custom `versions.yml` for testing in dev envs.

Doing that required some new settings -- whether to re-tag and push, which registry to push to, which components to process -- and  plumbing to make it possible to override those settings.

I also changed the defaults so that the dev case is easy to run (`rake sync` is pretty much all you need!) while the automated case uses production-specific settings.

There are some companion gpii-infra doc changes in https://github.com/gpii-ops/gpii-infra/pull/367.