### PR TITLE
GPII-3641: (version-updater) Restructure how upstream is specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ This workflow is a little cumbersome and is probably best for debugging version-
 
 Each top-level key is a `component`. The component's name is arbitrary, but should correlate with a gpii-infra module since gpii-infra will populate environment variables like `TF_VAR_<component_name>_(repository|tag|sha)` based on data under the component key in `versions.yml`.
 
-`sync_images` pulls the image specified by the component's `upstream_image` key, optionally processes the image further (e.g. push it to GCR), then populates the component's `generated` key with caluclated values.
+`sync_images` pulls the image specified by the component's `upstream.image` and `upstream.tag` keys, optionally processes the image further (e.g. pushing it to GCR), then populates the component's `generated` key with caluclated values.
 
 ### To add a new component
 
@@ -58,8 +58,8 @@ Each top-level key is a `component`. The component's name is arbitrary, but shou
    * Use `snake_case`, not `kebab-case`.
 1. Add a key underneath `my_component` called `repository`. Its value is the upstream location of the image, e.g. `mrtyler/universal` or `couchdb`.
 1. Add a key underneath `my_component` called `tag`. Its value is the tag on the upstream repository, e.g. `latest` or `2.3`.
-1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, my_component]"`
-   * `desired_components` (the last argument) accepts multiple, pipe-separated values: `flowmanager|preferences|dataloader`
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, my_component]"`
+   * `desired_components` (the `my_component` arg) accepts multiple, pipe-separated values: `flowmanager|preferences|dataloader`
 1. Review the changes made to `versions.yml` and commit.
 
 ### To modify a component
@@ -67,5 +67,5 @@ Each top-level key is a `component`. The component's name is arbitrary, but shou
 1. Find the component, e.g. `your_component`.
 1. Modify `repository` and `tag`.
 1. Ignore everything under `generated`; it will be re-generated.
-1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, your_component]"`
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, your_component]"`
 1. Review the changes made to `versions.yml` and commit.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,29 @@ This module contains:
 ## Generating `shared/versions.yml` manually
 
 `sync_images` can be useful for local GPII development. See [gpii-infra: I want to test my local changes to GPII components in my cluster](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/README.md#i-want-to-test-my-local-changes-to-gpii-components-in-my-cluster).
+
+## Adding or modifying a component
+
+`sync_images` reads a specified `versions.yml` file.
+
+Each top-level key is a `component`. The component's name is arbitrary, but should correlate with a gpii-infra module since gpii-infra will populate environment variables like `TF_VAR_<component_name>_(repository|tag|sha)` based on data under the component key in `versions.yml`.
+
+`sync_images` pulls the image specified by the component's `upstream_image` key, optionally processes the image further (e.g. push it to GCR), then populates the component's `generated` key with caluclated values.
+
+### To add a new component
+
+1. Add a new top-level key, `my_component`.
+   * Use `snake_case`, not `kebab-case`.
+1. Add a key underneath `my_component` called `repository`. Its value is the upstream location of the image, e.g. `mrtyler/universal` or `couchdb`.
+1. Add a key underneath `my_component` called `tag`. Its value is the tag on the upstream repository, e.g. `latest` or `2.3`.
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, my_component]"`
+   * `desired_components` (the last argument) accepts multiple, pipe-separated values: `flowmanager|preferences|dataloader`
+1. Review the changes made to `versions.yml` and commit.
+
+### To modify a component
+
+1. Find the component, e.g. `your_component`.
+1. Modify `repository` and `tag`.
+1. Ignore everything under `generated`; it will be re-generated.
+1. `rake sync"[/path/to/gpii-infra/shared/versions.yml, UNUSED, false, your_component]"`
+1. Review the changes made to `versions.yml` and commit.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This module contains:
    * To clean up: `rake uninstall`
 
 ## Running on host
-* `rake sync` to run `sync_images.rb` (see below)
+* `rake sync` to run `sync_images.rb`
    * You can override some defaults: `rake sync"[./my_versions.yml, gcr.io/gpii2test-common-stg]"`
 * `rake clean_cache` to destroy the Docker `/var/lib/docker` cache volume. The volume and cache will be re-created on the next run.
 * `rake test` to run unit tests
@@ -36,7 +36,9 @@ This workflow is a little cumbersome and is probably best for debugging version-
       * Add to the command line: `-v $(pwd)/fake-gpii-ci-ssh:/root/.ssh:ro,Z`
    * If you want to upload images (i.e. `push_to_gcr` is set to `true` -- this is the default for `sync_images_wrapper`), you must provide credentials with write access to the production GCR instance (or to the GCR instance you specified).
       * Add to the command line: `-v $(pwd)/creds.json:/home/app/creds.json:ro,Z`
-   * Omit `version-updater-docker-cache` if you want to re-pull the Docker images whenever you restart the container. Otherwise, provide the `-v version-updater-docker-cache` argument and clean it up afterwards with `rake clean_cache`.
+   * Omit `version-updater-docker-cache` if you want to re-pull the Docker images whenever you restart the container. Otherwise, clean up afterwards with `rake clean_cache`.
+1. Inside the container, start dockerd in the background: `dockerd &`
+1. `rake sync"[/path/to/versions.yml]"`, etc.
 
 ## Generating `shared/versions.yml` manually
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :test do
 end
 
 desc "Sync images"
-task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
+task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
     main(

--- a/Rakefile
+++ b/Rakefile
@@ -22,15 +22,15 @@ task :test do
   sh "bundle exec rspec"
 end
 
-desc "Sync images -- positional args are config_file, registry_url, push_to_gcr, desired_components"
-task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
+desc "Sync images -- positional args are config_file, desired_components, push_to_gcr, registry_url"
+task :sync, [:config_file, :desired_components, :push_to_gcr, :registry_url] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
     main(
       config_file=\"#{args[:config_file]}\",
-      registry_url=\"#{args[:registry_url]}\",
-      push_to_gcr=\"#{args[:push_to_gcr]}\",
       desired_components=\"#{args[:desired_components]}\",
+      push_to_gcr=\"#{args[:push_to_gcr]}\",
+      registry_url=\"#{args[:registry_url]}\",
     ); \
   '"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,11 +1,28 @@
+BUNDLE_PATH = "vendor/bundle"
+
 task :default => [:test]
+
+desc "Install dependencies"
+task :install do
+  sh "bundle install --path #{BUNDLE_PATH}"
+end
+
+desc "Uninstall dependencies"
+task :uninstall do
+  sh "rm -rf #{BUNDLE_PATH}"
+end
+
+desc "Destroy volume containing docker image cache"
+task :clean_cache do
+  sh "docker volume rm -f version-updater-docker-cache"
+end
 
 desc "Run tests"
 task :test do
   sh "bundle exec rspec"
 end
 
-desc "Sync images"
+desc "Sync images -- positional args are config_file, registry_url, push_to_gcr, desired_components"
 task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
@@ -16,11 +33,6 @@ task :sync, [:config_file, :registry_url, :push_to_gcr, :desired_components] do 
       desired_components=\"#{args[:desired_components]}\",
     ); \
   '"
-end
-
-desc "Destroy volume containing docker image cache"
-task :clean do
-  sh "docker volume rm -f version-updater-docker-cache"
 end
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,10 +6,14 @@ task :test do
 end
 
 desc "Sync images"
-task :sync, [:config_file, :registry_url] do |taskname, args|
+task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
   sh "bundle exec ruby -e '\
     require \"./sync_images.rb\";
-    main(config_file=\"#{args[:config_file]}\", registry_url=\"#{args[:registry_url]}\") \
+    main(
+      config_file=\"#{args[:config_file]}\",
+      registry_url=\"#{args[:registry_url]}\",
+      push_to_gcr=\"#{args[:push_to_gcr]}\",
+    ); \
   '"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -13,6 +13,7 @@ task :sync, [:config_file, :registry_url, :push_to_gcr] do |taskname, args|
       config_file=\"#{args[:config_file]}\",
       registry_url=\"#{args[:registry_url]}\",
       push_to_gcr=\"#{args[:push_to_gcr]}\",
+      desired_components=\"#{args[:desired_components]}\",
     ); \
   '"
 end

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -24,13 +24,14 @@ describe SyncImages do
       },
     }
     fake_registry_url = "gcr.fake/fake-project"
+    fake_push_to_gcr = true
 
     allow(SyncImages).to receive(:process_image)
 
-    SyncImages.process_config(fake_config, fake_registry_url)
+    SyncImages.process_config(fake_config, fake_registry_url, fake_push_to_gcr)
 
-    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url)
-    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url)
+    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
   end
 
   it "process_config generates new config" do
@@ -45,6 +46,7 @@ describe SyncImages do
       },
     }
     fake_registry_url = "gcr.fake/fake-project"
+    fake_push_to_gcr = true
     fake_new_image_name = "fake-registry/gpii/universal"
     fake_sha_1 = "sha256:c0ffee"
     fake_sha_2 = "sha256:50da"
@@ -74,7 +76,7 @@ describe SyncImages do
     )
     allow(SyncImages).to receive(:write_new_config)
 
-    actual = SyncImages.process_config(fake_config, fake_registry_url)
+    actual = SyncImages.process_config(fake_config, fake_registry_url, fake_push_to_gcr)
     expect(actual).to eq(expected_config)
   end
 

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -17,10 +17,16 @@ describe SyncImages do
   it "process_config calls process_image on each image when desired_components is _ALL_TOKEN" do
     fake_config = {
       "dataloader" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "flowmanager" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
     }
     fake_desired_components = SyncImages::DESIRED_COMPONENTS_ALL_TOKEN
@@ -31,23 +37,35 @@ describe SyncImages do
 
     SyncImages.process_config(fake_config, fake_desired_components, fake_push_to_gcr, fake_registry_url)
 
-    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
   end
 
   it "process_config calls process_image on DESIRED_COMPONENTS images when desired_components is _DEFAULT_TOKEN" do
     fake_config = {
       "preferences" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "dataloader" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "flowmanager" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "something_else" => {
-        "upstream_image" => "gpii/something_else:latest",
+        "upstream" => {
+          "repository" => "gpii/something_else",
+          "tag" => "latest",
+        }
       },
     }
     fake_desired_components = SyncImages::DESIRED_COMPONENTS_DEFAULT_TOKEN
@@ -58,22 +76,31 @@ describe SyncImages do
 
     SyncImages.process_config(fake_config, fake_desired_components, fake_push_to_gcr, fake_registry_url)
 
-    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).to have_received(:process_image).with("preferences", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).not_to have_received(:process_image).with("something_else", "gpii/something_else:latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("dataloader", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("preferences", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).not_to have_received(:process_image).with("something_else", "gpii/something_else", "latest", fake_registry_url, fake_push_to_gcr)
   end
 
   it "process_config calls process_image on some images when desired_components is specified" do
     fake_config = {
       "dataloader" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "flowmanager" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
       "something_else" => {
-        "upstream_image" => "gpii/something_else:1.0.0",
+        "upstream" => {
+          "repository" => "gpii/something_else",
+          "tag" => "1.0.0",
+        }
       },
     }
     fake_desired_components = "flowmanager|something_else"
@@ -84,15 +111,18 @@ describe SyncImages do
 
     SyncImages.process_config(fake_config, fake_desired_components, fake_push_to_gcr, fake_registry_url)
 
-    expect(SyncImages).not_to have_received(:process_image).with("dataloader", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal:latest", fake_registry_url, fake_push_to_gcr)
-    expect(SyncImages).to have_received(:process_image).with("something_else", "gpii/something_else:1.0.0", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).not_to have_received(:process_image).with("dataloader", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("flowmanager", "gpii/universal", "latest", fake_registry_url, fake_push_to_gcr)
+    expect(SyncImages).to have_received(:process_image).with("something_else", "gpii/something_else", "1.0.0", fake_registry_url, fake_push_to_gcr)
   end
 
   it "process_config does not explode when desired_components is not in config" do
     fake_config = {
       "dataloader" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
     }
     fake_desired_components = "something_else"
@@ -109,33 +139,45 @@ describe SyncImages do
     # (and thus get the shas in the right order).
     fake_config = {
       "something_else" => {
-        "upstream_image" => "gpii/something_else:latest",
+        "upstream" => {
+          "repository" => "gpii/something_else",
+          "tag" => "latest",
+        }
       },
       "flowmanager" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        }
       },
     }
     fake_desired_components = SyncImages::DESIRED_COMPONENTS_ALL_TOKEN
     fake_push_to_gcr = true
     fake_registry_url = "gcr.fake/fake-project"
-    fake_new_image_name_1 = "fake-registry/gpii/universal"
-    fake_new_image_name_2 = "fake-registry/gpii/something_else"
+    fake_new_repository_1 = "fake-registry/gpii/universal"
+    fake_new_repository_2 = "fake-registry/gpii/something_else"
     fake_sha_1 = "sha256:c0ffee"
     fake_sha_2 = "sha256:50da"
     fake_tag = "latest"
     expected_config = {
       "flowmanager" => {
-        "upstream_image" => "gpii/universal:latest",
+        "upstream" => {
+          "repository" => "gpii/universal",
+          "tag" => "latest",
+        },
         "generated" => {
-          "image" => fake_new_image_name_1,
+          "repository" => fake_new_repository_1,
           "sha" => fake_sha_1,
           "tag" => fake_tag,
         },
       },
       "something_else" => {
-        "upstream_image" => "gpii/something_else:latest",
+        "upstream" => {
+          "repository" => "gpii/something_else",
+          "tag" => "latest",
+        },
         "generated" => {
-          "image" => fake_new_image_name_2,
+          "repository" => fake_new_repository_2,
           "sha" => fake_sha_2,
           "tag" => fake_tag,
         },
@@ -143,8 +185,8 @@ describe SyncImages do
     }
 
     allow(SyncImages).to receive(:process_image).and_return(
-      [fake_new_image_name_1, fake_sha_1, fake_tag],
-      [fake_new_image_name_2, fake_sha_2, fake_tag],
+      [fake_new_repository_1, fake_sha_1, fake_tag],
+      [fake_new_repository_2, fake_sha_2, fake_tag],
     )
     allow(SyncImages).to receive(:write_new_config)
 
@@ -155,37 +197,35 @@ describe SyncImages do
   it "process_image calls all helpers on image when push_to_gcr is true" do
     fake_component = "fake_component"
     fake_image = "fake Docker::Image object"
-    fake_image_name = "fake_org/fake_img:fake_tag"
-    fake_image_name_without_tag = "fake_org/fake_img"
-    fake_registry_url = "gcr.fake/fake-project"
-    fake_new_image_name = "#{SyncImages::REGISTRY_URL}/#{fake_image_name}"
-    fake_new_image_name_without_tag = "#{SyncImages::REGISTRY_URL}/#{fake_image_name_without_tag}"
-    fake_sha = "sha256:c0ffee"
+    fake_repository = "fake_org/fake_img"
     fake_tag = "fake_tag"
+    fake_registry_url = "gcr.fake/fake-project"
+    fake_new_repository = "#{SyncImages::REGISTRY_URL}/#{fake_repository}"
+    fake_sha = "sha256:c0ffee"
     fake_push_to_gcr = true
 
     allow(SyncImages).to receive(:pull_image).and_return(fake_image)
-    allow(SyncImages).to receive(:retag_image).and_return(fake_new_image_name)
+    allow(SyncImages).to receive(:retag_image).and_return(fake_new_repository)
     allow(SyncImages).to receive(:get_sha_from_image).and_return(fake_sha)
     allow(SyncImages).to receive(:push_image)
 
-    actual = SyncImages.process_image(fake_component, fake_image_name, fake_registry_url, fake_push_to_gcr)
+    actual = SyncImages.process_image(fake_component, fake_repository, fake_tag, fake_registry_url, fake_push_to_gcr)
 
-    expect(SyncImages).to have_received(:pull_image).with(fake_image_name)
-    expect(SyncImages).to have_received(:retag_image).with(fake_image, fake_registry_url, fake_image_name)
-    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_image_name_without_tag)
-    expect(SyncImages).to have_received(:push_image).with(fake_image, fake_new_image_name)
-    expect(actual).to eq([fake_new_image_name_without_tag, fake_sha, fake_tag])
+    expect(SyncImages).to have_received(:pull_image).with(fake_repository, fake_tag)
+    expect(SyncImages).to have_received(:retag_image).with(fake_image, fake_registry_url, fake_repository, fake_tag)
+    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_repository)
+    expect(SyncImages).to have_received(:push_image).with(fake_image, fake_new_repository, fake_tag)
+    expect(actual).to eq([fake_new_repository, fake_sha, fake_tag])
   end
 
   it "process_image calls some helpers on image when push_to_gcr is false" do
     fake_component = "fake_component"
     fake_image = "fake Docker::Image object"
-    fake_image_name = "fake_org/fake_img:fake_tag"
-    fake_registry_url = "gcr.fake/fake-project"
-    fake_new_image_name_without_tag = "fake_org/fake_img"
-    fake_sha = "sha256:c0ffee"
+    fake_repository = "fake_org/fake_img"
     fake_tag = "fake_tag"
+    fake_registry_url = "gcr.fake/fake-project"
+    fake_new_repository = fake_repository
+    fake_sha = "sha256:c0ffee"
     fake_push_to_gcr = false
 
     allow(SyncImages).to receive(:pull_image).and_return(fake_image)
@@ -193,43 +233,44 @@ describe SyncImages do
     allow(SyncImages).to receive(:get_sha_from_image).and_return(fake_sha)
     allow(SyncImages).to receive(:push_image)
 
-    actual = SyncImages.process_image(fake_component, fake_image_name, fake_registry_url, fake_push_to_gcr)
+    actual = SyncImages.process_image(fake_component, fake_repository, fake_tag, fake_registry_url, fake_push_to_gcr)
 
-    expect(SyncImages).to have_received(:pull_image).with(fake_image_name)
+    expect(SyncImages).to have_received(:pull_image).with(fake_repository, fake_tag)
     expect(SyncImages).not_to have_received(:retag_image)
-    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_image_name_without_tag)
+    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_repository)
     expect(SyncImages).not_to have_received(:push_image)
-    expect(actual).to eq([fake_new_image_name_without_tag, fake_sha, fake_tag])
+    expect(actual).to eq([fake_new_repository, fake_sha, fake_tag])
   end
 
   it "pull_image pulls image" do
-    fake_image_name = "fake_org/fake_img:fake_tag"
+    fake_repository = "fake_org/fake_img"
+    fake_tag = "fake_tag"
     fake_image = "fake docker image object"
     allow(Docker::Image).to receive(:create).and_return(fake_image)
-    actual = SyncImages.pull_image(fake_image_name)
+    actual = SyncImages.pull_image(fake_repository, fake_tag)
     expect(actual).to eq(fake_image)
-    expect(Docker::Image).to have_received(:create).with({"fromImage" => fake_image_name}, creds: {})
+    expect(Docker::Image).to have_received(:create).with({"fromImage" => fake_repository, "tag" => fake_tag}, creds: {})
   end
 
-  it "get_sha_from_image gets sha that starts with new_image_name" do
+  it "get_sha_from_image gets sha that starts with new_repository" do
     fake_image = double(Docker::Image)
-    fake_new_image_name_without_tag = "fake_org/fake_img"
+    fake_new_repository = "fake_org/fake_img"
     fake_sha = "sha256:c0ffee"
     allow(fake_image).to receive(:info).and_return({
       "RepoDigests" => [
         "another_org/another_img@sha256:50da",
         # Target is not first so that we avoid a false negative when
         # get_sha_from_image falls back to "return first RepoDigest" behavior.
-        "#{fake_new_image_name_without_tag}@#{fake_sha}",
+        "#{fake_new_repository}@#{fake_sha}",
       ]
     })
-    actual = SyncImages.get_sha_from_image(fake_image, fake_new_image_name_without_tag)
+    actual = SyncImages.get_sha_from_image(fake_image, fake_new_repository)
     expect(actual).to eq(fake_sha)
   end
 
-  it "get_sha_from_image gets first sha if no digest starts with new_image_name" do
+  it "get_sha_from_image gets first sha if no digest starts with new_repository" do
     fake_image = double(Docker::Image)
-    fake_new_image_name_without_tag = "this image name is not in RepoDigests"
+    fake_new_repository = "this repository is not in RepoDigests"
     fake_sha = "sha256:c0ffee"
     allow(fake_image).to receive(:info).and_return({
       "RepoDigests" => [
@@ -237,42 +278,45 @@ describe SyncImages do
         "another_org/another_img@sha256:50da",
       ]
     })
-    actual = SyncImages.get_sha_from_image(fake_image, fake_new_image_name_without_tag)
+    actual = SyncImages.get_sha_from_image(fake_image, fake_new_repository)
     expect(actual).to eq(fake_sha)
   end
 
   it "get_sha_from_image explodes when RepoDigests is empty" do
     fake_image = double(Docker::Image)
-    fake_new_image_name_without_tag = "fake_org/fake_img"
+    fake_new_repository = "fake_org/fake_img"
     allow(fake_image).to receive(:info).and_return({
       "RepoDigests" => [],
     })
-    expect { SyncImages.get_sha_from_image(fake_image, fake_new_image_name_without_tag) }.to raise_error(ArgumentError, /Could not find sha!/)
+    expect { SyncImages.get_sha_from_image(fake_image, fake_new_repository) }.to raise_error(ArgumentError, /Could not find sha!/)
   end
 
   it "retag_image retags iamge" do
     fake_image = double(Docker::Image)
     fake_registry_url = "gcr.fake/fake-project"
-    fake_image_name = "fake_org/fake_img:fake_tag"
-    fake_new_image_name = "#{fake_registry_url}/#{fake_image_name}"
+    fake_repository = "fake_org/fake_img"
+    fake_tag = "fake_tag"
+    fake_new_repository = "#{fake_registry_url}/#{fake_repository}"
 
     allow(fake_image).to receive(:tag)
-    actual = SyncImages.retag_image(fake_image, fake_registry_url, fake_image_name)
-    expect(fake_image).to have_received(:tag).with({"repo" => fake_new_image_name})
-    expect(actual).to eq(fake_new_image_name)
+    actual = SyncImages.retag_image(fake_image, fake_registry_url, fake_repository, fake_tag)
+    expect(fake_image).to have_received(:tag).with({"repo" => fake_new_repository, "tag" => fake_tag})
+    expect(actual).to eq(fake_new_repository)
   end
 
   it "push_image pushes image" do
     fake_image = double(Docker::Image)
-    fake_new_image_name = "fake_registry/fake_org/fake_img:fake_tag"
+    fake_new_repository = "fake_registry/fake_org/fake_img"
+    fake_tag = "fake_tag"
     allow(fake_image).to receive(:push)
-    SyncImages.push_image(fake_image, fake_new_image_name)
-    expect(fake_image).to have_received(:push).with(nil, "repo_tag": fake_new_image_name)
+    SyncImages.push_image(fake_image, fake_new_repository, fake_tag)
+    expect(fake_image).to have_received(:push).with(nil, "repo_tag": "#{fake_new_repository}:#{fake_tag}")
   end
 
   it "push_image explodes if push output contains error" do
     fake_image = double(Docker::Image)
-    fake_new_image_name = "fake_registry/fake_org/fake_img:fake_tag"
+    fake_new_repository = "fake_registry/fake_org/fake_img"
+    fake_tag = "fake_tag"
     # Based on real output when I accidentally mismatched credentials and
     # registry.
     fake_output = [
@@ -281,7 +325,7 @@ describe SyncImages do
       '{"errorDetail":{"message":"unauthorized: incorrect username or password"},"error":"unauthorized: incorrect username or password"}',
     ]
     allow(fake_image).to receive(:push).and_yield(fake_output[0]).and_yield(fake_output[1]).and_yield(fake_output[2])
-    expect { SyncImages.push_image(fake_image, fake_new_image_name) }.to raise_error(ArgumentError, /Found error message in output/)
+    expect { SyncImages.push_image(fake_image, fake_new_repository, fake_tag) }.to raise_error(ArgumentError, /Found error message in output/)
   end
 
   # It is not necessary or desirable to test File.write or YAML.dump, but this

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -49,7 +49,7 @@ describe SyncImages do
     }
     fake_registry_url = "gcr.fake/fake-project"
     fake_push_to_gcr = true
-    fake_desired_components = "flowmanager,something_else"
+    fake_desired_components = "flowmanager|something_else"
 
     allow(SyncImages).to receive(:process_image)
 

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -158,7 +158,7 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
     desired_components = SyncImages::DESIRED_COMPONENTS
   end
   config = SyncImages.load_config(config_file)
-  SyncImages.login()
+  SyncImages.login() if push_to_gcr
   SyncImages.process_config(config, registry_url, push_to_gcr, desired_components)
   SyncImages.write_new_config(config_file, config)
 end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -37,12 +37,18 @@ class SyncImages
     return config
   end
 
-  def self.process_image(component, image_name, registry_url)
+  def self.process_image(component, image_name, registry_url, push_to_gcr)
     image = self.pull_image(image_name)
-    new_image_name = self.retag_image(image, registry_url, image_name)
-    new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
-    sha = self.get_sha_from_image(image, new_image_name_without_tag)
-    self.push_image(image, new_image_name)
+    if push_to_gcr
+      new_image_name = self.retag_image(image, registry_url, image_name)
+      new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
+      sha = self.get_sha_from_image(image, new_image_name_without_tag)
+      self.push_image(image, new_image_name)
+    else
+      new_image_name = image_name
+      new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
+      sha = self.get_sha_from_image(image, new_image_name_without_tag)
+    end
 
     return [new_image_name_without_tag, sha, tag]
   end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -29,7 +29,7 @@ class SyncImages
   def self.process_config(config, registry_url, push_to_gcr, desired_components)
     desired_components_table = {}  # Empty hash means "all components"
     unless desired_components.nil?
-      desired_components.split(",").each do |dc|
+      desired_components.split("|").each do |dc|
         desired_components_table[dc] = true
       end
     end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,6 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
+  PUSH_TO_GCR = true
   REGISTRY_URL = "gcr.io/gpii-common-prd"
 
   def self.load_config(config_file)
@@ -24,10 +25,10 @@ class SyncImages
     )
   end
 
-  def self.process_config(config, registry_url)
+  def self.process_config(config, registry_url, push_to_gcr)
     config.keys.sort.each do |component|
       image_name = config[component]["upstream_image"]
-      (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url)
+      (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url, push_to_gcr)
       config[component]["generated"] = {
         "image" => new_image_name,
         "sha" => sha,
@@ -123,16 +124,19 @@ class SyncImages
 end
 
 
-def main(config_file, registry_url)
+def main(config_file, registry_url, push_to_gcr)
   if config_file.nil? or config_file.empty?
     config_file = SyncImages::CONFIG_FILE
   end
   if registry_url.nil? or registry_url.empty?
     registry_url = SyncImages::REGISTRY_URL
   end
+  if push_to_gcr.nil? or push_to_gcr.empty?
+    push_to_gcr = SyncImages::PUSH_TO_GCR
+  end
   config = SyncImages.load_config(config_file)
   SyncImages.login()
-  SyncImages.process_config(config, registry_url)
+  SyncImages.process_config(config, registry_url, push_to_gcr)
   SyncImages.write_new_config(config_file, config)
 end
 

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -53,6 +53,7 @@ class SyncImages
   end
 
   def self.process_image(component, image_name, registry_url, push_to_gcr)
+    puts "Processing image for #{component}..."
     image = self.pull_image(image_name)
     if push_to_gcr
       new_image_name = self.retag_image(image, registry_url, image_name)
@@ -64,6 +65,8 @@ class SyncImages
       new_image_name_without_tag, tag = Docker::Util.parse_repo_tag(new_image_name)
       sha = self.get_sha_from_image(image, new_image_name_without_tag)
     end
+    puts "Done with #{component}."
+    puts
 
     return [new_image_name_without_tag, sha, tag]
   end
@@ -148,6 +151,9 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
   if push_to_gcr.nil? or push_to_gcr.empty?
     push_to_gcr = SyncImages::PUSH_TO_GCR
   end
+  # Due to how we pass arguments through rake, 'false' ends up as a string.
+  # Correct it into a boolean.
+  push_to_gcr = false if push_to_gcr == "false"
   if desired_components.nil? or desired_components.empty?
     desired_components = SyncImages::DESIRED_COMPONENTS
   end

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,8 +8,10 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = nil  # "nil" means all components
-  PUSH_TO_GCR = true
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "preferences"]
+  DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
+  DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
+  PUSH_TO_GCR = false
   REGISTRY_URL = "gcr.io/gpii-common-prd"
 
   def self.load_config(config_file)
@@ -26,22 +28,22 @@ class SyncImages
     )
   end
 
-  def self.process_config(config, registry_url, push_to_gcr, desired_components)
-    desired_components_table = {}  # Empty hash means "all components"
-    unless desired_components.nil?
-      desired_components.split("|").each do |dc|
-        desired_components_table[dc] = true
-      end
+  def self.process_config(config, desired_components, push_to_gcr, registry_url)
+    if desired_components == SyncImages::DESIRED_COMPONENTS_ALL_TOKEN
+      components = config.keys.sort.each
+    elsif desired_components == SyncImages::DESIRED_COMPONENTS_DEFAULT_TOKEN
+      components = SyncImages::DESIRED_COMPONENTS
+    else
+      components = desired_components.split("|")
     end
 
-    config.keys.sort.each do |component|
-      # Ruby style suggests "unless X or Y", but I find that more confusing than
-      # "if not X and not Y".
-      #
-      # Anyway, skip this component if desired_components were specified AND
-      # this component is not in the set of desired_components.
-      next if (not desired_components_table.empty? and not desired_components_table.has_key?(component))
-      image_name = config[component]["upstream_image"]
+    components.each do |component|
+      begin
+        image_name = config[component]["upstream_image"]
+      rescue
+        puts "Could not find desired component #{component} (or its 'upstream_image' attribute)! Skipping!"
+        next
+      end
       (new_image_name, sha, tag) = self.process_image(component, image_name, registry_url, push_to_gcr)
       config[component]["generated"] = {
         "image" => new_image_name,
@@ -141,12 +143,12 @@ class SyncImages
 end
 
 
-def main(config_file, registry_url, push_to_gcr, desired_components)
+def main(config_file, desired_components, push_to_gcr, registry_url)
   if config_file.nil? or config_file.empty?
     config_file = SyncImages::CONFIG_FILE
   end
-  if registry_url.nil? or registry_url.empty?
-    registry_url = SyncImages::REGISTRY_URL
+  if desired_components.nil? or desired_components.empty?
+    desired_components = SyncImages::DESIRED_COMPONENTS_DEFAULT_TOKEN
   end
   if push_to_gcr.nil? or push_to_gcr.empty?
     push_to_gcr = SyncImages::PUSH_TO_GCR
@@ -154,12 +156,13 @@ def main(config_file, registry_url, push_to_gcr, desired_components)
   # Due to how we pass arguments through rake, 'false' ends up as a string.
   # Correct it into a boolean.
   push_to_gcr = false if push_to_gcr == "false"
-  if desired_components.nil? or desired_components.empty?
-    desired_components = SyncImages::DESIRED_COMPONENTS
+  if registry_url.nil? or registry_url.empty?
+    registry_url = SyncImages::REGISTRY_URL
   end
+
   config = SyncImages.load_config(config_file)
   SyncImages.login() if push_to_gcr
-  SyncImages.process_config(config, registry_url, push_to_gcr, desired_components)
+  SyncImages.process_config(config, desired_components, push_to_gcr, registry_url)
   SyncImages.write_new_config(config_file, config)
 end
 

--- a/sync_images_wrapper
+++ b/sync_images_wrapper
@@ -28,7 +28,7 @@ while true ; do
     git fetch --all --depth=10 -p
     git reset --hard origin/master
 
-    (cd "${orig_dir}" && rake sync"[${gpii_infra_dir}/${versions_file}]")
+    (cd "${orig_dir}" && rake sync"[${gpii_infra_dir}/${versions_file}, ALL, true, gcr.io/gcp-common-prd]")
     if [ -n "$(git status --porcelain -- ${versions_file})" ]; then
         git add "${versions_file}"
         git commit -m"[auto] Update ${versions_file}"

--- a/sync_images_wrapper
+++ b/sync_images_wrapper
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This initial setup is essential, so abort if anything fails.
+# Abort if anything fails.
 set -e
 
 orig_dir="$(pwd)"
@@ -20,9 +20,6 @@ git clone --no-tags --depth 10 git@github.com:gpii-ops/gpii-infra
 cd gpii-infra
 gpii_infra_dir="$(pwd)"
 
-# Failures in the main loop are ok, so continue if anything fails and try again
-# on the next go around.
-set +e
 while true ; do
     echo "Starting version check at $(date)"
     git fetch --all --depth=10 -p

--- a/sync_images_wrapper
+++ b/sync_images_wrapper
@@ -31,6 +31,7 @@ while true ; do
     (cd "${orig_dir}" && rake sync"[${gpii_infra_dir}/${versions_file}, ALL, true, gcr.io/gcp-common-prd]")
     if [ -n "$(git status --porcelain -- ${versions_file})" ]; then
         git add "${versions_file}"
+        git --no-pager diff --cached
         git commit -m"[auto] Update ${versions_file}"
         git push origin HEAD
     fi


### PR DESCRIPTION
See https://github.com/gpii-ops/gpii-version-updater/pull/13#issuecomment-483892637.

Must be deployed with https://github.com/gpii-ops/gpii-infra/pull/368.

This PR is on top of #17. First new commit is 4e7a917.

Sorry about the lack of targeted commits; I found it easiest to change names and structures as I found them. A summary:
* Restructure `upstream_image` (which included a tag) to `upstream.repository` and `upstream.tag`.
* Rename `(new_)image_name` to `(new_)repository`.
* Refactor to pass `tag` along with `repository` where needed.
* Replace `(new_)repository_without_tag` to `(new_)repository`.
