### PR TITLE
Update rake version to match gpii-infra.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GEM
       multi_json
     excon (0.62.0)
     multi_json (1.13.1)
-    rake (12.3.2)
+    rake (12.3.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module contains:
 ## Installing on host
 
 1. Follow the [gpii-infra instructions for installing packages.](https://github.com/gpii-ops/gpii-infra/blob/master/gcp/README.md#install-packages).
+1. Install the `bundler` gem, e.g. with `gem install bundler` or with your system's package manager.
 1. Clone this repo.
 1. `cd gpii-version-updater`
 1. `rake install`


### PR DESCRIPTION
Add instrution for installing bundler (removed from gpii-infra install instructions some time ago).

This fixes some bugs @klown found while running through the workflow.