### PR TITLE
GPII-3888:  Run universal dockerDeleteExpiredAccessTokens.sh in Kubernetes

### DIFF
--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,7 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "flushtokens", "istio_proxy_manager", "preferences"]
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "flushtokens", "preferences"]
   DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
   DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
   PUSH_TO_GCR = false

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,7 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "preferences"]
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "flushtokens", "preferences"]
   DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
   DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
   PUSH_TO_GCR = false

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,7 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "flushtokens", "preferences"]
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "flushtokens", "istio_proxy_manager", "preferences"]
   DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
   DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
   PUSH_TO_GCR = false


### PR DESCRIPTION
JIRA: https://issues.gpii.net/browse/GPII-3888

Note: works in tandem with [PR #478](https://github.com/gpii-ops/gpii-infra/pull/478)

~~Note: works in tandem with [PR #383](https://github.com/gpii-ops/gpii-infra/pull/383)~~