### PR TITLE
GPII-3860: Flatten repository when syncing

### DIFF
--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -296,7 +296,7 @@ describe SyncImages do
     fake_registry_url = "gcr.fake/fake-project"
     fake_repository = "fake_org/fake_img"
     fake_tag = "fake_tag"
-    fake_new_repository = "#{fake_registry_url}/#{fake_repository}"
+    fake_new_repository = "#{fake_registry_url}/fake_org__fake_img"
 
     allow(fake_image).to receive(:tag)
     actual = SyncImages.retag_image(fake_image, fake_registry_url, fake_repository, fake_tag)

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -105,7 +105,10 @@ class SyncImages
   end
 
   def self.retag_image(image, registry_url, repository, tag)
-    new_repository = "#{registry_url}/#{repository}"
+    # Many applications (Docker Hub, GKE Binary Authorization
+    # admission_whitelist_patterns) do not support slashes after the "username"
+    # component (e.g. host.name/username/image).
+    new_repository = "#{registry_url}/#{repository.gsub("/", "__")}"
     puts "Retagging #{repository} as #{new_repository}..."
     image.tag("repo" => new_repository, "tag" => tag)
     return new_repository


### PR DESCRIPTION
[Stepan anticipated](https://github.com/gpii-ops/gpii-infra/pull/348#issuecomment-483314730) that this nested structure might be a problem, but the final straw was that GKE Binary Authorization admission patterns don't allow slashes in image names.

Deploy plan will be in ticket (EDIT: https://issues.gpii.net/browse/GPII-3860?focusedCommentId=39513&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-39513).

While this PR does not (should not :)) make any functional changes, it will change the Docker images and SHAs in use and thus will cause Pod restarts. This probably won't matter much in practice, as other changes in the deploy (e.g. enabling binauth) will be more disruptive.