### PR TITLE
GPII-3907: Re-pull image so that we (consistently) get the SHA based on the pushed image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This module contains:
 This workflow is a little cumbersome and is probably best for debugging version-udpater itself.
 
 1. `docker pull gpii/version-updater`
-1. Run the container in interactive mode: `docker run --privileged -it -v version-updater-docker-cache:/var/lib/docker gpii/version-updater sh`
+1. Run the container in interactive mode: `docker run --privileged --rm -it -v version-updater-docker-cache:/var/lib/docker gpii/version-updater sh`
    * If you want to read and write the versions.yml automatically (e.g. by running `sync_images_wrapper`), you must provide a directory containing a `id_rsa.gpii-ci` usable for pulling and pushing to the gpii-infra repo.
       * Add to the command line: `-v $(pwd)/fake-gpii-ci-ssh:/root/.ssh:ro,Z`
    * If you want to upload images (i.e. `push_to_gcr` is set to `true` -- this is the default for `sync_images_wrapper`), you must provide credentials with write access to the production GCR instance (or to the GCR instance you specified).

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -296,7 +296,7 @@ describe SyncImages do
     fake_registry_url = "gcr.fake/fake-project"
     fake_repository = "fake_org/fake_img"
     fake_tag = "fake_tag"
-    fake_new_repository = "#{fake_registry_url}/#{fake_repository}"
+    fake_new_repository = "#{fake_registry_url}/fake_org__fake_img"
 
     allow(fake_image).to receive(:tag)
     actual = SyncImages.retag_image(fake_image, fake_registry_url, fake_repository, fake_tag)

--- a/spec/sync_images_spec.rb
+++ b/spec/sync_images_spec.rb
@@ -206,15 +206,16 @@ describe SyncImages do
 
     allow(SyncImages).to receive(:pull_image).and_return(fake_image)
     allow(SyncImages).to receive(:retag_image).and_return(fake_new_repository)
-    allow(SyncImages).to receive(:get_sha_from_image).and_return(fake_sha)
     allow(SyncImages).to receive(:push_image)
+    allow(SyncImages).to receive(:get_sha_from_image).and_return(fake_sha)
 
     actual = SyncImages.process_image(fake_component, fake_repository, fake_tag, fake_registry_url, fake_push_to_gcr)
 
     expect(SyncImages).to have_received(:pull_image).with(fake_repository, fake_tag)
     expect(SyncImages).to have_received(:retag_image).with(fake_image, fake_registry_url, fake_repository, fake_tag)
-    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_repository)
     expect(SyncImages).to have_received(:push_image).with(fake_image, fake_new_repository, fake_tag)
+    expect(SyncImages).to have_received(:pull_image).with(fake_new_repository, fake_tag)
+    expect(SyncImages).to have_received(:get_sha_from_image).with(fake_image, fake_new_repository)
     expect(actual).to eq([fake_new_repository, fake_sha, fake_tag])
   end
 

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -60,8 +60,10 @@ class SyncImages
     image = self.pull_image(repository, tag)
     if push_to_gcr
       new_repository = self.retag_image(image, registry_url, repository, tag)
-      sha = self.get_sha_from_image(image, new_repository)
       self.push_image(image, new_repository, tag)
+      # Re-pull image so that we (consistently) get the SHA based on the pushed image.
+      image = self.pull_image(new_repository, tag)
+      sha = self.get_sha_from_image(image, new_repository)
     else
       new_repository = repository
       sha = self.get_sha_from_image(image, new_repository)

--- a/sync_images.rb
+++ b/sync_images.rb
@@ -105,7 +105,10 @@ class SyncImages
   end
 
   def self.retag_image(image, registry_url, repository, tag)
-    new_repository = "#{registry_url}/#{repository}"
+    # Many applications (Docker Hub, GKE Binary Authorization
+    # admission_whitelist_patterns) do not support slashes after the "username"
+    # component (e.g. host.name/username/image).
+    new_repository = "#{registry_url}/#{repository.gsub("/", "__")}"
     puts "Retagging #{repository} as #{new_repository}..."
     image.tag("repo" => new_repository, "tag" => tag)
     return new_repository


### PR DESCRIPTION
This is on top of #23, so please ignore those commits.

I figured I'd take a crack at this issue while making changes for GPII-3860. In my local tests, I could repro the SHA changing on the second run for some images (I still don't know exactly what causes the double change, but it happens consistently with four of the images in versionsyml). With my fix, the correct file was generated on the first run.