### PR TITLE
GPII-3832: Version updater for running the production configuration tests in GCP

### DIFF
--- a/sync_images.rb
+++ b/sync_images.rb
@@ -8,7 +8,7 @@ class SyncImages
 
   CONFIG_FILE = "../gpii-infra/shared/versions.yml"
   CREDS_FILE = "./creds.json"
-  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "preferences"]
+  DESIRED_COMPONENTS = ["dataloader", "flowmanager", "preferences", "productiontests"]
   DESIRED_COMPONENTS_ALL_TOKEN = "ALL"
   DESIRED_COMPONENTS_DEFAULT_TOKEN = "DEFAULT"
   PUSH_TO_GCR = false


### PR DESCRIPTION
This pull request is paired with pull #[347](https://github.com/gpii-ops/gpii-infra/pull/347) for `gpii-infra`.  That PR adds code to `gpii-infra` that runs `gpii-universal`'s production configuration tests as a one-shot job in the standard cloud setup for GPII.

JIRA: https://issues.gpii.net/browse/GPII-3832